### PR TITLE
doc(readme): add build instruction for libfuse-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ For some background, see [this thread](https://forum.safedev.org/t/filetree-crdt
 # Building
 
 1. You need rust 1.46.0 or higher installed.
-2. `$ git clone https://github.com/maidsafe/sn_fs`
-3. `$ cd sn_fs && cargo build`
+2. You need fuse development package installed, eg `libfuse-dev` on Ubuntu.
+3. `$ git clone https://github.com/maidsafe/sn_fs`
+4. `$ cd sn_fs && cargo build`
 
 # Usage
 


### PR DESCRIPTION
@S-Coyle  reports that without OS (Ubuntu) libfuse-dev package installed, build fails with:

```
$  cargo build
   Compiling getrandom v0.1.15
   Compiling atty v0.2.14
   Compiling time v0.1.44
   Compiling openat v0.1.19
   Compiling regex v1.3.9
   Compiling quote v1.0.7
   Compiling fuse v0.3.1
   Compiling num-integer v0.1.43
error: failed to run custom build command for `fuse v0.3.1`
Caused by:
  process didn't exit successfully: `/home/maidsafe/Projects/sn_fs/target/debug/build/fuse-956058acc8a1b157/build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=FUSE_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=FUSE_STATIC
  cargo:rerun-if-env-changed=FUSE_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Failure { command: "\"pkg-config\" \"--libs\" \"--cflags\" \"fuse\" \"fuse >= 2.6.0\"", output: Output { status: ExitStatus(ExitStatus(256)), stdout: "", stderr: "Package fuse was not found in the pkg-config search path.\nPerhaps you should add the directory containing `fuse.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'fuse\' found\nPackage fuse was not found in the pkg-config search path.\nPerhaps you should add the directory containing `fuse.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'fuse\' found\n" } }', /home/maidsafe/.cargo/registry/src/github.com-1ecc6299db9ec823/fuse-0.3.1/build.rs:10:76
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```