### PR TITLE
fix(main): remove allow_other option when mounting fs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1199,7 +1199,7 @@ fn main() {
     //  2. allow_other enables other users to read/write.  Required for testing chown.
     //  3. allow_other requires that `user_allow_other` is in /etc/fuse.conf.
     //    let options = ["-o", "ro", "-o", "fsname=safefs"]    // -o ro = mount read only
-    let options = ["-o", "fsname=sn_fs,allow_other"]
+    let options = ["-o", "fsname=sn_fs"]
         .iter()
         .map(|o| o.as_ref())
         .collect::<Vec<&OsStr>>();


### PR DESCRIPTION
This was preventing mount from occurring without a special option in fuse.conf.   It is not needed, so I removed it.   Thanks @Yoga07 for the report.